### PR TITLE
в сервер можно  добавлять обработчиков на определённые шаблоны путей

### DIFF
--- a/src/main/java/ru/netology/ClientSocket.java
+++ b/src/main/java/ru/netology/ClientSocket.java
@@ -1,67 +1,34 @@
 package ru.netology;
 
-import ru.netology.setting.CommonFilesResources;
-import ru.netology.setting.IValidPaths;
 
 import java.io.*;
 import java.net.Socket;
-import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 public class ClientSocket implements Runnable {
 
-    private static final int NUMBER_ELEMENT_INTO_REQUEST_LINE = 3;
-    private static final String SEPARATOR_INTO_REQUEST_LINE = " ";
-    private final IValidPaths validPaths;
     private final Socket clientSocket;
+    private final Server server;
     private final BufferedReader in;
     private final BufferedOutputStream out;
-    private final CommonFilesResources filesResources;
 
-    public ClientSocket(Socket socket, IValidPaths validPaths) throws IOException {
+    public ClientSocket(Socket socket, Server server) throws IOException {
 
+        this.server = server;
         this.clientSocket = socket;
-        this.validPaths = validPaths;
         in = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
         out = new BufferedOutputStream(clientSocket.getOutputStream());
-        filesResources = CommonFilesResources.getInstance();
     }
 
     @Override
     public void run() {
         try {
-            // read only request line for simplicity
-            // must be in form GET /path HTTP/1.1
-            final var requestLine = in.readLine();
-            final var parts = requestLine.split(SEPARATOR_INTO_REQUEST_LINE);
-
-            if (parts.length == NUMBER_ELEMENT_INTO_REQUEST_LINE) {
-                final var path = parts[1];
-                final var pathValid = validPaths.getPathFile(path);
-                if (pathValid.isPresent()) {
-                    final var filePath = pathValid.get();
-                    final var type = filesResources.getTypeFile(filePath);
-                    final var len = filesResources.getLengthFile(filePath);
-                    if (type.isPresent() && len.isPresent()) {
-                        final var mimeType = type.get();
-                        final var length = len.getAsLong();
-
-                        // special case for classic
-                        if (path.equals("/classic.html")) {
-                            final var template = filesResources.getContentFile(filePath).get();
-                            final var content = template.replace("{time}", LocalDateTime.now().toString()).getBytes();
-                            out.write(getResponseHead(mimeType, content.length).getBytes());
-                            out.write(content);
-                        } else {
-                            out.write(getResponseHead(mimeType, length).getBytes());
-                            Object o = filesResources.copyFileIntoOutputStream(filePath, out).get();
-                        }
-                        out.flush();
-                    } else {
-                        out.write(getResponseError404().getBytes());
-                        out.flush();
-                    }
-                }
+            final var requestLines =  in.readLine();
+            Request request = new Request();
+            if(request.parsingRequestLine(requestLines)){
+                Map<String, IHandler> map = server.getHandlersByKey(request.getMethod().get());
+                map.get(request.getMessage()).handle(request, out);
             }
         } catch (IOException e) {
             e.printStackTrace();
@@ -83,18 +50,4 @@ public class ClientSocket implements Runnable {
         }
     }
 
-    private String getResponseHead(String mimeType, long lenBody) {
-        return "HTTP/1.1 200 OK\r\n" +
-                "Content-Type: " + mimeType + "\r\n" +
-                "Content-Length: " + lenBody + "\r\n" +
-                "Connection: close\r\n" +
-                "\r\n";
-    }
-
-    private String getResponseError404() {
-        return "HTTP/1.1 404 Not Found\r\n" +
-                "Content-Length: 0\r\n" +
-                "Connection: close\r\n" +
-                "\r\n";
-    }
 }

--- a/src/main/java/ru/netology/IHandler.java
+++ b/src/main/java/ru/netology/IHandler.java
@@ -1,0 +1,10 @@
+package ru.netology;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.ExecutionException;
+
+public interface IHandler {
+    void handle(Request request, BufferedOutputStream out) throws IOException, ExecutionException, InterruptedException;
+}

--- a/src/main/java/ru/netology/Request.java
+++ b/src/main/java/ru/netology/Request.java
@@ -1,0 +1,72 @@
+package ru.netology;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public class Request {
+
+    private static final String SEPARATOR_INTO_REQUEST_LINE = " ";
+    private static final int NUMBER_ELEMENT_INTO_REQUEST_LINE = 3;
+    private RequestMethods method;
+    private List<String> listHeadLines = new ArrayList<>();
+
+    private String message;
+    private String body;
+
+    
+
+    public RequestMethods getMethod() {
+        return method;
+    }
+
+    public void setMethod(RequestMethods method) {
+        this.method = method;
+    }
+
+    public List<String> getListHeadLines() {
+        return listHeadLines;
+    }
+
+    public void setListHeadLines(List<String> listHeadLines) {
+        this.listHeadLines = listHeadLines;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public boolean parsingRequestLine(String line){
+        var parts = line.split(SEPARATOR_INTO_REQUEST_LINE);
+        if (parts.length != NUMBER_ELEMENT_INTO_REQUEST_LINE) {
+            return false;
+        }
+        method = parts[0].transform(s -> {
+            for(var t: RequestMethods.values()){
+                if(t.get().equals(s)){
+                    return t;
+                }
+            }
+            return null;
+        });
+        message = parts[1];
+        return true;
+    }
+    public boolean parsingRequest(String request){
+        return true;
+
+    }
+}

--- a/src/main/java/ru/netology/RequestMethods.java
+++ b/src/main/java/ru/netology/RequestMethods.java
@@ -1,0 +1,19 @@
+package ru.netology;
+
+public enum RequestMethods {
+    GET("GET"),
+    POST("POST"),
+    PUT("PUT"),
+    DELETE("DELETE"),
+    HEAD("HEAD"),
+    PATCH("PATCH"),
+    TRACE("TRACE"),
+    CONNECT("CONNECT");
+    private String method;
+    RequestMethods(String method){
+        this.method = method;
+    }
+    public String get(){
+        return method;
+    }
+}

--- a/src/main/java/ru/netology/Server.java
+++ b/src/main/java/ru/netology/Server.java
@@ -1,23 +1,55 @@
 package ru.netology;
 
 import ru.netology.setting.CommonSetting;
+import ru.netology.setting.HandlerShaper;
 import ru.netology.setting.ValidPathsStorage;
 
 import java.io.*;
 import java.net.ServerSocket;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Server {
+    private final Map<String, Map<String, IHandler>> handlers = new ConcurrentHashMap<>(16);
+    private static Server server;
     public static void main(String[] args) {
+        server = new Server();
+
+        var handlerShaper = new HandlerShaper(ValidPathsStorage.getInstance());
+        for(String path: ValidPathsStorage.getInstance().getValidPaths()){
+            server.addHandler(RequestMethods.GET.get(), path, handlerShaper.getHandler(RequestMethods.GET));
+            server.addHandler(RequestMethods.POST.get(), path, handlerShaper.getHandler(RequestMethods.POST));
+        }
+        server.listen(CommonSetting.SERVER_PORT);
+    }
+    public void listen(int port){
         PoolThread poolThread = PoolThread.getInstance();
 
-        try (final var serverSocket = new ServerSocket(CommonSetting.SERVER_PORT)) {
+        try (final var serverSocket = new ServerSocket(port)) {
             while (true) {
-                poolThread.getPool().submit(new ClientSocket(serverSocket.accept(), ValidPathsStorage.getInstance()));
+                poolThread.getPool().submit(new ClientSocket(serverSocket.accept(), server));
             }
         } catch (IOException e) {
             e.printStackTrace();
         } finally {
             poolThread.setInterrupt();
         }
+    }
+
+    public Map<String, Map<String, IHandler>> getAllHandlers() {
+        return handlers;
+    }
+
+    private void addHandler(String method, String path, IHandler handler){
+        if(handlers.containsKey(method)){
+          handlers.get(method).put(path, handler);
+        }else {
+            Map<String, IHandler> map = new ConcurrentHashMap<>(16);
+            map.put(path, handler);
+            handlers.put(method, map);
+        }
+    }
+    public Map<String, IHandler> getHandlersByKey(String key){
+        return handlers.get(key);
     }
 }

--- a/src/main/java/ru/netology/setting/CommonFilesResources.java
+++ b/src/main/java/ru/netology/setting/CommonFilesResources.java
@@ -36,11 +36,11 @@ public class CommonFilesResources {
         return Optional.empty();
     }
 
-    public synchronized Future<String> getContentFile(Path path) throws IOException {
+    public synchronized Future<String> getContentFile(Path path) {
         return pool.submit(() -> Files.readString(path));
     }
 
-    public synchronized Future<?> copyFileIntoOutputStream(Path path, OutputStream out) throws IOException {
+    public synchronized Future<?> copyFileIntoOutputStream(Path path, OutputStream out) {
         return pool.submit(() -> Files.copy(path, out));
     }
 }

--- a/src/main/java/ru/netology/setting/HandlerShaper.java
+++ b/src/main/java/ru/netology/setting/HandlerShaper.java
@@ -1,0 +1,57 @@
+package ru.netology.setting;
+
+import ru.netology.IHandler;
+import ru.netology.RequestMethods;
+
+import java.time.LocalDateTime;
+
+public class HandlerShaper {
+    private final IValidPaths validPaths;
+
+    public HandlerShaper(IValidPaths validPaths) {
+        this.validPaths = validPaths;
+    }
+    public IHandler getHandler(RequestMethods methods){
+
+        return (((request, out) -> {
+            final var filePath = validPaths.getPathFile(request.getMessage()).get();
+            final var filesResources = CommonFilesResources.getInstance();
+            final var type = filesResources.getTypeFile(filePath);
+            final var len = filesResources.getLengthFile(filePath);
+            if (type.isPresent() && len.isPresent()) {
+                final var mimeType = type.get();
+                final var length = len.getAsLong();
+                // special case for classic
+                if (request.getMessage().equals("/classic.html")) {
+                    final var template = filesResources.getContentFile(filePath).get();
+                    final var content = template.replace("{time}", LocalDateTime.now().toString()).getBytes();
+                    out.write(getResponseHead(mimeType, content.length).getBytes());
+                    out.write(content);
+                } else {
+                    out.write(getResponseHead(mimeType, length).getBytes());
+                    filesResources.copyFileIntoOutputStream(filePath, out).get();
+                }
+                out.flush();
+            } else {
+                out.write(getResponseError404().getBytes());
+                out.flush();
+            }
+        }));
+    }
+
+    private String getResponseHead(String mimeType, long lenBody) {
+        return "HTTP/1.1 200 OK\r\n" +
+                "Content-Type: " + mimeType + "\r\n" +
+                "Content-Length: " + lenBody + "\r\n" +
+                "Connection: close\r\n" +
+                "\r\n";
+    }
+
+    private String getResponseError404() {
+        return "HTTP/1.1 404 Not Found\r\n" +
+                "Content-Length: 0\r\n" +
+                "Connection: close\r\n" +
+                "\r\n";
+    }
+
+}


### PR DESCRIPTION
Принимаем запрос, собираем объект, типа Request.
На основании данных из Request выбираем хендлер (он может быть только один), который и будет обрабатывать запрос.
Все хендлеры храниться в полях Server.
Самый простой способ хранить хендлеры — это использовать в качестве ключей метод и путь. Можно сделать как Map внутри Map, так и отдельные Map на каждый метод.
Поиск хендлера заключается в том, что выбираем по нужному методу все зарегистрированные хендлеры, а затем перебираем по пути.
Найдя нужный хендлер, достаточно вызвать его метод handle, передав туда Request и BufferedOutputStream.